### PR TITLE
Feat/championship

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -78,6 +78,8 @@ model College {
     updatedAt DateTime    @updatedAt
     Users     User[]
     type      CollegeType @default(ENGINEERING)
+    championshipPoints Int
+    Teams     Team[]
 }
 
 model Branch {
@@ -108,6 +110,7 @@ model Event {
     maxTeamSize      Int                @default(1)
     maxTeams         Int?
     published        Boolean            @default(false)
+    tier             EventTier          @default(GOLD)
     Branch           Branch             @relation(fields: [branchId], references: [id], onDelete: Restrict)
     Teams            Team[]
     Rounds           Round[]
@@ -120,9 +123,10 @@ model Event {
 }
 
 model Team {
-    id   Int    @id @default(autoincrement())
-    name String
-
+    id                Int    @id @default(autoincrement())
+    name              String
+    collegeId         Int?
+    College           College?            @relation(fields: [collegeId], references: [id], onDelete: Cascade)
     createdAt         DateTime            @default(now())
     updatedAt         DateTime            @updatedAt
     eventId           Int
@@ -142,6 +146,7 @@ model Team {
 
     @@unique([name, eventId])
     @@index([eventId, roundNo])
+    @@index([collegeId])
 }
 
 model Round {
@@ -549,6 +554,12 @@ enum EventCategory {
     NON_TECHNICAL
     CORE
     SPECIAL
+}
+
+enum EventTier {
+    GOLD
+    SILVER
+    BRONZE
 }
 
 enum CollegeType {

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -12,6 +12,7 @@ const main = async () => {
     data: {
       name: "NMAM Institute of Technology",
       type: "ENGINEERING",
+      championshipPoints: 0,
     },
   });
 
@@ -73,6 +74,7 @@ const main = async () => {
       }),
       fees: 100,
       maxTeams: 10,
+      tier: "GOLD",
       minTeamSize: 2,
       maxTeamSize: 3,
       eventType: "INDIVIDUAL_MULTIPLE_ENTRY",
@@ -149,6 +151,11 @@ const main = async () => {
         },
       },
       leaderId: teamMembers[0].id,
+      College: {
+        connect: {
+          id: teamMembers[0].collegeId ?? undefined,
+        },
+      },
       TeamMembers: {
         createMany: {
           data: Array.from(teamMembers, (member) => ({

--- a/src/graphql/models/College/index.ts
+++ b/src/graphql/models/College/index.ts
@@ -12,5 +12,6 @@ builder.prismaObject("College", {
   fields: (t) => ({
     id: t.exposeID("id"),
     name: t.exposeString("name"),
+    championshipPoints: t.exposeInt("championshipPoints"),
   }),
 });

--- a/src/graphql/models/College/mutation.ts
+++ b/src/graphql/models/College/mutation.ts
@@ -23,6 +23,7 @@ builder.mutationField("createCollege", (t) =>
         data: {
           name: args.name,
           details: args.details,
+          championshipPoints: 0,
         },
       });
     },

--- a/src/graphql/models/Event/mutation.ts
+++ b/src/graphql/models/Event/mutation.ts
@@ -1,4 +1,4 @@
-import { EventCategory, EventType } from "@prisma/client";
+import { EventCategory, EventTier, EventType } from "@prisma/client";
 
 import { builder } from "~/graphql/builder";
 
@@ -73,6 +73,10 @@ const EventUpdateInput = builder.inputType("EventUpdateInput", {
     maxTeams: t.int({ required: false }),
     venue: t.string({ required: false }),
     image: t.string({ required: false }),
+    tier: t.field({
+      type: EventTier,
+      required: false,
+    }),
     category: t.field({
       type: EventCategory,
       required: false,

--- a/src/graphql/models/Team/index.ts
+++ b/src/graphql/models/Team/index.ts
@@ -12,6 +12,9 @@ builder.prismaObject("Team", {
     members: t.relation("TeamMembers"),
     confirmed: t.exposeBoolean("confirmed"),
     attended: t.exposeBoolean("attended"),
+    college: t.relation("College", {
+      nullable: true,
+    }),
     leaderId: t.exposeInt("leaderId", {
       nullable: true,
     }),

--- a/src/graphql/models/Team/mutation.ts
+++ b/src/graphql/models/Team/mutation.ts
@@ -90,6 +90,7 @@ builder.mutationField("createTeam", (t) =>
         data: {
           name: args.name,
           eventId: Number(args.eventId),
+          collegeId: Number(user.collegeId),
           TeamMembers: {
             create: {
               userId: user.id,
@@ -529,6 +530,7 @@ builder.mutationField("registerSoloEvent", (t) =>
         data: {
           name: user.id.toString(),
           eventId: Number(args.eventId),
+          collegeId: Number(user.collegeId),
           leaderId: user.id,
           confirmed: !isPaidEvent,
           TeamMembers: {
@@ -700,7 +702,7 @@ builder.mutationField("organizerAddTeamMember", (t) =>
       ) {
         throw new Error("Not authorized");
       }
-      if (!(user.College?.type === "ENGINEERING")) {
+      if (!(participant.College?.type === "ENGINEERING")) {
         if (
           !(await canRegister(
             participant.id,
@@ -760,6 +762,11 @@ builder.mutationField("organizerAddTeamMember", (t) =>
           },
           data: {
             leaderId: participant.id,
+            College: {
+              connect: {
+                id: participant.College?.id,
+              },
+            },
           },
         });
 
@@ -1139,7 +1146,7 @@ builder.mutationField("organizerRegisterSolo", (t) =>
         throw new Error(`No participant with id ${args.userId}`);
       }
 
-      if (!(user.College?.type === "ENGINEERING")) {
+      if (!(participant.College?.type === "ENGINEERING")) {
         if (
           !(await canRegister(
             participant.id,
@@ -1179,6 +1186,7 @@ builder.mutationField("organizerRegisterSolo", (t) =>
           attended: true,
           confirmed: true,
           leaderId: Number(args.userId),
+          collegeId: participant.collegeId,
           TeamMembers: {
             create: {
               userId: Number(args.userId),

--- a/src/graphql/models/Winner/index.ts
+++ b/src/graphql/models/Winner/index.ts
@@ -3,6 +3,7 @@ import { WinnerType } from "@prisma/client";
 import { builder } from "~/graphql/builder";
 import "~/graphql/models/Winner/mutation";
 import "~/graphql/models/Winner/query";
+import "~/graphql/models/Winner/subscription";
 
 builder.enumType(WinnerType, {
   name: "WinnerType",

--- a/src/graphql/models/Winner/mutation.ts
+++ b/src/graphql/models/Winner/mutation.ts
@@ -1,6 +1,7 @@
 import { WinnerType } from "@prisma/client";
 
 import { builder } from "~/graphql/builder";
+import { allocatePoints } from "./utils";
 
 builder.mutationField("createWinner", (t) =>
   t.prismaField({
@@ -36,6 +37,7 @@ builder.mutationField("createWinner", (t) =>
         },
         select: {
           category: true,
+          tier: true,
           Rounds: {
             select: {
               completed: true,
@@ -67,6 +69,7 @@ builder.mutationField("createWinner", (t) =>
         },
         include: {
           TeamMembers: true,
+          College: true,
         },
       });
 
@@ -90,64 +93,97 @@ builder.mutationField("createWinner", (t) =>
       if (winner) {
         throw new Error("Winner already exists");
       }
-      const data = await ctx.prisma.winners.create({
-        data: {
-          teamId: Number(args.teamId),
-          eventId: Number(args.eventId),
-          type: args.type,
-        },
-        ...query,
-      });
-      //check if winner level exists
-      const levelExists = await ctx.prisma.level.findFirst({
-        where: {
-          winnerId: data.id,
-        },
-      });
-      //get full team userId
-      const teamMembers = team.TeamMembers.map((member) => member.userId);
-      if (levelExists) {
-        //check if team members are already given xp points
-        const xp = await ctx.prisma.xP.findMany({
-          where: {
-            userId: {
-              in: teamMembers,
-            },
-            levelId: levelExists.id,
+
+      try {
+        const { data, collegeData } = await ctx.prisma.$transaction(
+          async (prisma) => {
+            const data = await ctx.prisma.winners.create({
+              data: {
+                teamId: Number(args.teamId),
+                eventId: Number(args.eventId),
+                type: args.type,
+              },
+              ...query,
+            });
+
+            const points = allocatePoints(event.tier, args.type);
+
+            const collegeData = await ctx.prisma.college.update({
+              where: { id: team.College?.id },
+              data: {
+                championshipPoints: {
+                  increment: Number(points),
+                },
+              },
+            });
+
+            //check if winner level exists
+            const levelExists = await ctx.prisma.level.findFirst({
+              where: {
+                winnerId: data.id,
+              },
+            });
+            //get full team userId
+            const teamMembers = team.TeamMembers.map((member) => member.userId);
+            if (levelExists) {
+              //check if team members are already given xp points
+              const xp = await ctx.prisma.xP.findMany({
+                where: {
+                  userId: {
+                    in: teamMembers,
+                  },
+                  levelId: levelExists.id,
+                },
+              });
+              if (xp.length == 0) {
+                //give xp points to all team members
+                await ctx.prisma.xP.createMany({
+                  data: teamMembers.map((userId) => ({
+                    userId,
+                    levelId: levelExists.id,
+                  })),
+                });
+              }
+            } else {
+              // give xp points for winning
+              let point =
+                args.type === "WINNER"
+                  ? 100
+                  : args.type === "RUNNER_UP"
+                    ? 75
+                    : 50;
+              if (event.category === "CORE") {
+                point =
+                  args.type === "WINNER"
+                    ? 150
+                    : args.type === "RUNNER_UP"
+                      ? 100
+                      : 75;
+              }
+              const level = await ctx.prisma.level.create({
+                data: {
+                  point: point,
+                  winnerId: data.id,
+                },
+              });
+              //give xp points to all team members
+              await ctx.prisma.xP.createMany({
+                data: teamMembers.map((userId) => ({
+                  userId,
+                  levelId: level.id,
+                })),
+              });
+            }
+            return { data, collegeData };
           },
-        });
-        if (xp.length == 0) {
-          //give xp points to all team members
-          await ctx.prisma.xP.createMany({
-            data: teamMembers.map((userId) => ({
-              userId,
-              levelId: levelExists.id,
-            })),
-          });
-        }
-      } else {
-        // give xp points for winning
-        let point =
-          args.type === "WINNER" ? 100 : args.type === "RUNNER_UP" ? 75 : 50;
-        if (event.category === "CORE") {
-          point =
-            args.type === "WINNER" ? 150 : args.type === "RUNNER_UP" ? 100 : 75;
-        }
-        const level = await ctx.prisma.level.create({
-          data: {
-            point: point,
-            winnerId: data.id,
-          },
-        });
-        //give xp points to all team members
-        await ctx.prisma.xP.createMany({
-          data: teamMembers.map((userId) => ({
-            userId,
-            levelId: level.id,
-          })),
-        });
+        );
+
+        await ctx.pubsub.publish("CHAMPIONSHIP_UPDATED", collegeData);
+
+        return data;
+      } catch (error) {
+        throw new Error("Winner could not be created, please try again");
       }
-      return data;
     },
   }),
 );
@@ -177,6 +213,7 @@ builder.mutationField("deleteWinner", (t) =>
         include: {
           Team: {
             select: {
+              College: true,
               TeamMembers: {
                 select: {
                   userId: true,
@@ -203,6 +240,7 @@ builder.mutationField("deleteWinner", (t) =>
           },
         },
         select: {
+          tier: true,
           Rounds: {
             select: {
               Judges: true,
@@ -225,38 +263,62 @@ builder.mutationField("deleteWinner", (t) =>
       ) {
         throw new Error("Not authorized");
       }
-      //delete winner xp points
-      const level = await ctx.prisma.level.findFirst({
-        where: {
-          winnerId: Number(args.id),
-        },
-      });
-      //get all team members id
-      const teamMembers = winner.Team.TeamMembers.map(
-        (member) => member.userId,
-      );
-      if (level) {
-        await ctx.prisma.xP.deleteMany({
-          where: {
-            userId: {
-              in: teamMembers,
-            },
-            levelId: level.id,
+
+      try {
+        const { data, collegeData } = await ctx.prisma.$transaction(
+          async (prisma) => {
+            //delete winner xp points
+            const level = await ctx.prisma.level.findFirst({
+              where: {
+                winnerId: Number(args.id),
+              },
+            });
+            //get all team members id
+            const teamMembers = winner.Team.TeamMembers.map(
+              (member) => member.userId,
+            );
+            if (level) {
+              await ctx.prisma.xP.deleteMany({
+                where: {
+                  userId: {
+                    in: teamMembers,
+                  },
+                  levelId: level.id,
+                },
+              });
+              await ctx.prisma.level.delete({
+                where: {
+                  id: level.id,
+                },
+              });
+            }
+
+            const points = allocatePoints(event.tier, winner.type);
+            const collegeData = await ctx.prisma.college.update({
+              where: { id: winner.Team.College?.id },
+              data: {
+                championshipPoints: {
+                  decrement: Number(points),
+                },
+              },
+            });
+
+            const data = await ctx.prisma.winners.delete({
+              where: {
+                id: Number(args.id),
+              },
+              ...query,
+            });
+            return { data, collegeData };
           },
-        });
-        await ctx.prisma.level.delete({
-          where: {
-            id: level.id,
-          },
-        });
+        );
+
+        await ctx.pubsub.publish(`CHAMPIONSHIP_UPDATED`, collegeData);
+
+        return data;
+      } catch (error) {
+        throw new Error("could not delete winner, please try again");
       }
-      const data = await ctx.prisma.winners.delete({
-        where: {
-          id: Number(args.id),
-        },
-        ...query,
-      });
-      return data;
     },
   }),
 );

--- a/src/graphql/models/Winner/subscription.ts
+++ b/src/graphql/models/Winner/subscription.ts
@@ -1,0 +1,156 @@
+import { builder } from "~/graphql/builder";
+import { prisma } from "~/utils/db";
+
+class CountClass {
+  WINNER: number;
+  RUNNER_UP: number;
+  SECOND_RUNNER_UP: number;
+  constructor(WINNER: number, RUNNER_UP: number, SECOND_RUNNER_UP: number) {
+    this.WINNER = WINNER;
+    this.RUNNER_UP = RUNNER_UP;
+    this.SECOND_RUNNER_UP = SECOND_RUNNER_UP;
+  }
+}
+
+class ChampionshipPointsClass {
+  collegeId: number;
+  collegeName: string;
+  championshipPoints: number;
+  goldCount: CountClass;
+  silverCount: CountClass;
+  bronzeCount: CountClass;
+  constructor(
+    collegeId: number,
+    championshipPoints: number,
+    collegeName: string,
+    goldCount: CountClass,
+    silverCount: CountClass,
+    bronzeCount: CountClass,
+  ) {
+    this.collegeName = collegeName;
+    this.collegeId = collegeId;
+    this.championshipPoints = championshipPoints;
+    this.goldCount = goldCount;
+    this.silverCount = silverCount;
+    this.bronzeCount = bronzeCount;
+  }
+}
+
+const Count = builder.objectType(CountClass, {
+  name: "Counts",
+  fields: (t) => ({
+    winner: t.exposeInt("WINNER"),
+    runner_up: t.exposeInt("RUNNER_UP"),
+    second_runner_up: t.exposeInt("SECOND_RUNNER_UP"),
+  }),
+});
+
+const ChampionshipPoints = builder.objectType(ChampionshipPointsClass, {
+  name: "ChampionshipPoint",
+  fields: (t) => ({
+    id: t.exposeInt("collegeId"),
+    name: t.exposeString("collegeName"),
+    championshipPoints: t.exposeInt("championshipPoints"),
+    goldCount: t.expose("goldCount", {
+      type: Count,
+    }),
+    silverCount: t.expose("silverCount", {
+      type: Count,
+    }),
+    bronzeCount: t.expose("bronzeCount", {
+      type: Count,
+    }),
+  }),
+});
+
+builder.queryField("getChampionshipPoints", (t) =>
+  t.field({
+    type: [ChampionshipPoints],
+    errors: {
+      types: [Error],
+    },
+    smartSubscription: true,
+    subscribe: (subscription, root, args, ctx, info) => {
+      subscription.register(`CHAMPIONSHIP_UPDATED`);
+    },
+    resolve: async (root, args, ctx, info) => {
+      const user = await ctx.user;
+      if (!user) {
+        throw new Error("Not authenticated");
+      }
+      if (user.role !== "JURY") {
+        throw new Error("Not authorized");
+      }
+      const winners = await prisma.winners.findMany({
+        include: {
+          Team: {
+            include: {
+              College: true,
+            },
+          },
+          Event: true,
+        },
+      });
+
+      const colleges = await prisma.college.findMany();
+
+      const collegePoints = colleges.map((collegeItem) => {
+        const collegeData: ChampionshipPointsClass = {
+          collegeId: collegeItem.id,
+          collegeName: collegeItem.name,
+          championshipPoints: collegeItem.championshipPoints,
+          goldCount: { WINNER: 0, RUNNER_UP: 0, SECOND_RUNNER_UP: 0 },
+          silverCount: { WINNER: 0, RUNNER_UP: 0, SECOND_RUNNER_UP: 0 },
+          bronzeCount: { WINNER: 0, RUNNER_UP: 0, SECOND_RUNNER_UP: 0 },
+        };
+
+        const collegeWinners = winners.filter(
+          (winner) => winner.Team.College?.id === collegeItem.id,
+        );
+
+        collegeWinners.forEach((winner) => {
+          if (!winner.Event) return;
+          if (winner.Event.tier === "GOLD") {
+            collegeData.goldCount[winner.type]++;
+          } else if (winner.Event.tier === "SILVER") {
+            collegeData.silverCount[winner.type]++;
+          } else if (winner.Event.tier === "BRONZE") {
+            collegeData.bronzeCount[winner.type]++;
+          }
+        });
+
+        return collegeData;
+      });
+      return collegePoints;
+    },
+  }),
+);
+/*
+const data : Object = 
+    {
+        "data": {
+          "collegesWithStats": [
+            {
+              "id": "1",
+              "name": "Engineering College A",
+              "championshipPoints": 120,
+              "goldCount": {
+                "WINNER": 10,
+                "RUNNER_UP": 2,
+                "SECOND_RUNNER_UP": 3
+              },
+              "silverCount": {
+                "WINNER": 0,
+                "RUNNER_UP": 1,
+                "SECOND_RUNNER_UP": 3
+              },
+              "bronzeCount": {
+                "WINNER": 0,
+                "RUNNER_UP": 1,
+                "SECOND_RUNNER_UP": 3
+              }
+            }
+          ]
+        }
+      }
+*/

--- a/src/graphql/models/Winner/utils.ts
+++ b/src/graphql/models/Winner/utils.ts
@@ -1,0 +1,26 @@
+type Tier = "GOLD" | "SILVER" | "BRONZE";
+type winnerType = "WINNER" | "RUNNER_UP" | "SECOND_RUNNER_UP";
+
+const allocatePoints = (tier: Tier, winnerType: winnerType): number => {
+  const pointsTable: Record<Tier, Record<winnerType, number>> = {
+    GOLD: {
+      WINNER: 500,
+      RUNNER_UP: 450,
+      SECOND_RUNNER_UP: 400,
+    },
+    SILVER: {
+      WINNER: 350,
+      RUNNER_UP: 300,
+      SECOND_RUNNER_UP: 250,
+    },
+    BRONZE: {
+      WINNER: 200,
+      RUNNER_UP: 150,
+      SECOND_RUNNER_UP: 100,
+    },
+  };
+
+  return pointsTable[tier][winnerType];
+};
+
+export { allocatePoints };


### PR DESCRIPTION
schema.prisma - added eventTier, college relation to Team, championshipPoints

~graphql/models/Winners - transaction to update championshipPoints and subscription publish
~graphql/models/Winners/subscription.ts - generates college wise report of points, check end of file for structure.